### PR TITLE
Fix WeatherForecast API to return data

### DIFF
--- a/BookStoreApp.API/Controllers/WeatherForecastController.cs
+++ b/BookStoreApp.API/Controllers/WeatherForecastController.cs
@@ -19,27 +19,26 @@ namespace BookStoreApp.API.Controllers
         }
 
         [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
-        { 
+        public ActionResult<IEnumerable<WeatherForecast>> Get()
+        {
             _logger.LogInformation("Getting weather forecast");
             try
             {
-                throw new Exception("This is our logging test exception");
-                return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+                var forecasts = Enumerable.Range(1, 5).Select(index => new WeatherForecast
                     {
                         Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
                         TemperatureC = Random.Shared.Next(-20, 55),
                         Summary = Summaries[Random.Shared.Next(Summaries.Length)]
                     })
                     .ToArray();
+
+                return Ok(forecasts);
             }
             catch (Exception ex)
             {
-               _logger.LogError(ex,"Fatal Error Occurred.");
-                throw;
+                _logger.LogError(ex, "Error generating weather forecast");
+                return StatusCode(500);
             }
-           
-            
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove test exception from WeatherForecast endpoint
- return generated forecasts and log any errors

## Testing
- `dotnet build BookStoreApp.sln`

------
https://chatgpt.com/codex/tasks/task_e_6845c8a8c5a483218d5b4535081e7cd1