### PR TITLE
Add error handling middleware

### DIFF
--- a/BookStoreApp.API/Controllers/WeatherForecastController.cs
+++ b/BookStoreApp.API/Controllers/WeatherForecastController.cs
@@ -22,8 +22,6 @@ namespace BookStoreApp.API.Controllers
         public IEnumerable<WeatherForecast> Get()
         { 
             _logger.LogInformation("Getting weather forecast");
-            try
-            {
                 throw new Exception("This is our logging test exception");
                 return Enumerable.Range(1, 5).Select(index => new WeatherForecast
                     {
@@ -32,12 +30,6 @@ namespace BookStoreApp.API.Controllers
                         Summary = Summaries[Random.Shared.Next(Summaries.Length)]
                     })
                     .ToArray();
-            }
-            catch (Exception ex)
-            {
-               _logger.LogError(ex,"Fatal Error Occurred.");
-                throw;
-            }
            
             
         }

--- a/BookStoreApp.API/Middleware/ErrorHandlingMiddleware.cs
+++ b/BookStoreApp.API/Middleware/ErrorHandlingMiddleware.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace BookStoreApp.API.Middleware
+{
+    public class ErrorHandlingMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ILogger<ErrorHandlingMiddleware> _logger;
+
+        public ErrorHandlingMiddleware(RequestDelegate next, ILogger<ErrorHandlingMiddleware> logger)
+        {
+            _next = next;
+            _logger = logger;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            try
+            {
+                await _next(context);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An unhandled exception has occurred.");
+                context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                context.Response.ContentType = "application/json";
+
+                var problem = new
+                {
+                    title = "An unexpected error occurred",
+                    status = 500,
+                    detail = ex.Message
+                };
+
+                var json = JsonSerializer.Serialize(problem, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                });
+
+                await context.Response.WriteAsync(json);
+            }
+        }
+    }
+}

--- a/BookStoreApp.API/Program.cs
+++ b/BookStoreApp.API/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using BookStoreApp.API.Middleware;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,6 +35,9 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+
+app.UseMiddleware<ErrorHandlingMiddleware>();
 
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
## Summary
- add `ErrorHandlingMiddleware` to log and return JSON errors
- wire middleware before HTTPS redirection
- simplify `WeatherForecastController` by removing try/catch

## Testing
- `dotnet build BookStoreApp.API/BookStoreApp.API.csproj -v minimal`
- `dotnet test BookStoreApp.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6845df35fe2c8321b1171c5c6a51271c