### PR TITLE
Implement cached weather forecasts

### DIFF
--- a/BookStoreApp.API/Controllers/WeatherForecastController.cs
+++ b/BookStoreApp.API/Controllers/WeatherForecastController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using BookStoreApp.API.Services;
 
 namespace BookStoreApp.API.Controllers
 {
@@ -6,40 +7,20 @@ namespace BookStoreApp.API.Controllers
     [Route("[controller]")]
     public class WeatherForecastController : ControllerBase
     {
-        private static readonly string[] Summaries = new[]
-        {
-            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-        };
-
         private readonly ILogger<WeatherForecastController> _logger;
+        private readonly IWeatherService _weatherService;
 
-        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        public WeatherForecastController(ILogger<WeatherForecastController> logger, IWeatherService weatherService)
         {
             _logger = logger;
+            _weatherService = weatherService;
         }
 
         [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
-        { 
+        public async Task<IEnumerable<WeatherForecast>> Get()
+        {
             _logger.LogInformation("Getting weather forecast");
-            try
-            {
-                throw new Exception("This is our logging test exception");
-                return Enumerable.Range(1, 5).Select(index => new WeatherForecast
-                    {
-                        Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                        TemperatureC = Random.Shared.Next(-20, 55),
-                        Summary = Summaries[Random.Shared.Next(Summaries.Length)]
-                    })
-                    .ToArray();
-            }
-            catch (Exception ex)
-            {
-               _logger.LogError(ex,"Fatal Error Occurred.");
-                throw;
-            }
-           
-            
+            return await _weatherService.GetCachedForecastsAsync();
         }
     }
 }

--- a/BookStoreApp.API/Program.cs
+++ b/BookStoreApp.API/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using BookStoreApp.API.Services;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,6 +12,8 @@ Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(builder.Configurat
 builder.Host.UseSerilog();
 
 builder.Services.AddControllers();
+builder.Services.AddMemoryCache();
+builder.Services.AddScoped<IWeatherService, WeatherService>();
 
 
 builder.Services.AddEndpointsApiExplorer();

--- a/BookStoreApp.API/Services/IWeatherService.cs
+++ b/BookStoreApp.API/Services/IWeatherService.cs
@@ -1,0 +1,9 @@
+using BookStoreApp.API;
+
+namespace BookStoreApp.API.Services
+{
+    public interface IWeatherService
+    {
+        Task<IEnumerable<WeatherForecast>> GetCachedForecastsAsync();
+    }
+}

--- a/BookStoreApp.API/Services/WeatherService.cs
+++ b/BookStoreApp.API/Services/WeatherService.cs
@@ -1,0 +1,49 @@
+using BookStoreApp.API;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace BookStoreApp.API.Services
+{
+    public class WeatherService : IWeatherService
+    {
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<WeatherService> _logger;
+        private static readonly string[] Summaries = new[]
+        {
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+        };
+        private const string CacheKey = "weather_forecasts";
+
+        public WeatherService(IMemoryCache cache, ILogger<WeatherService> logger)
+        {
+            _cache = cache;
+            _logger = logger;
+        }
+
+        public Task<IEnumerable<WeatherForecast>> GetCachedForecastsAsync()
+        {
+            if (!_cache.TryGetValue(CacheKey, out IEnumerable<WeatherForecast>? forecasts))
+            {
+                _logger.LogInformation("Generating new weather forecasts");
+                forecasts = Enumerable.Range(1, 5).Select(index => new WeatherForecast
+                    {
+                        Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                        TemperatureC = Random.Shared.Next(-20, 55),
+                        Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                    })
+                    .ToArray();
+
+                var cacheOptions = new MemoryCacheEntryOptions()
+                    .SetSlidingExpiration(TimeSpan.FromMinutes(5));
+
+                _cache.Set(CacheKey, forecasts, cacheOptions);
+            }
+            else
+            {
+                _logger.LogInformation("Retrieving weather forecasts from cache");
+            }
+
+            return Task.FromResult(forecasts!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IMemoryCache support and register WeatherService
- implement WeatherService with cache logic
- inject the service into WeatherForecastController
- use the cached forecast retrieval

## Testing
- `dotnet build BookStoreApp.API/BookStoreApp.API.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6845df39be3483219263c09481531581